### PR TITLE
WIP: Implement support for anonymous inititators

### DIFF
--- a/src/gss_creds.c
+++ b/src/gss_creds.c
@@ -430,6 +430,14 @@ uint32_t gssntlm_acquire_cred_from(uint32_t *minor_status,
     }
 
     if (cred_usage == GSS_C_INITIATE) {
+        if (name != NULL && name->type == GSSNTLM_NAME_ANON) {
+            cred->type = GSSNTLM_CRED_ANON;
+            cred->cred.anon.dummy = 0;
+            retmin = 0;
+            retmaj = 0;
+            goto done;
+        }
+
         if (name != NULL && name->type != GSSNTLM_NAME_USER) {
             set_GSSERRS(ERR_NOUSRNAME, GSS_S_BAD_NAMETYPE);
             goto done;

--- a/src/gss_names.c
+++ b/src/gss_names.c
@@ -157,6 +157,8 @@ uint32_t gssntlm_import_name_by_mech(uint32_t *minor_status,
     /* TODO: check mech_type == gssntlm_oid */
     if (mech_type == GSS_C_NO_OID) {
         return GSSERRS(ERR_NOARG, GSS_S_CALL_INACCESSIBLE_READ);
+    } else if (!gss_oid_equal(mech_type, &gssntlm_oid)) {
+        return GSSERRS(ERR_BADARG, GSS_S_BAD_MECH);
     }
 
     name = calloc(1, sizeof(struct gssntlm_name));

--- a/src/gss_names.c
+++ b/src/gss_names.c
@@ -761,6 +761,7 @@ static uint32_t make_ma_oid_set(uint32_t *minor_status, gss_OID_set *ma_set,
         GSS_C_MA_OOS_DET,
         GSS_C_MA_CBINDINGS,
         GSS_C_MA_CTX_TRANS,
+        GSS_C_MA_AUTH_INIT_ANON,
         NULL
     };
     uint32_t maj = 0;

--- a/src/gss_ntlmssp.c
+++ b/src/gss_ntlmssp.c
@@ -193,3 +193,16 @@ int gssntlm_get_lm_compatibility_level(void)
     /* use 3 by default for better compatibility */
     return 3;
 }
+
+bool gssntlm_is_anonymous_allowed(void)
+{
+    const char *envvar;
+
+    envvar = getenv("NTLM_ALLOW_ANONYMOUS");
+    if (envvar != NULL) {
+        return (atoi(envvar) > 0);
+    }
+
+    /* Not allowed by default */
+    return false;
+}

--- a/src/gss_ntlmssp.h
+++ b/src/gss_ntlmssp.h
@@ -178,6 +178,7 @@ uint32_t gssntlm_context_is_valid(struct gssntlm_ctx *ctx,
                                   time_t *time_now);
 
 int gssntlm_get_lm_compatibility_level(void);
+bool gssntlm_is_anonymous_allowed(void);
 
 void gssntlm_int_release_name(struct gssntlm_name *name);
 void gssntlm_int_release_cred(struct gssntlm_cred *cred);

--- a/src/gss_sec_ctx.c
+++ b/src/gss_sec_ctx.c
@@ -996,6 +996,8 @@ done:
         if (time_rec) *time_rec = GSS_C_INDEFINITE;
     }
     *context_handle = (gss_ctx_id_t)ctx;
+    gssntlm_release_cred(&tmpmin, (gss_cred_id_t *)&usr_cred);
+    gssntlm_release_name(&tmpmin, (gss_name_t *)&gss_usrname);
     gssntlm_release_name(&tmpmin, (gss_name_t *)&server_name);
     safefree(computer_name);
     safefree(nb_computer_name);

--- a/tests/ntlmssptest.c
+++ b/tests/ntlmssptest.c
@@ -2153,7 +2153,7 @@ int test_gssapi_rfc5587(void)
         return EINVAL;
     }
 
-    if (mech_attrs->count != 9) {
+    if (mech_attrs->count != 10) {
         fprintf(stderr, "expected 9 mech_attr oids, got %lu\n",
                 mech_attrs->count);
         return EINVAL;

--- a/tests/ntlmssptest.c
+++ b/tests/ntlmssptest.c
@@ -2261,6 +2261,240 @@ int test_ZERO_LMKEY(struct ntlm_ctx *ctx)
     return test_keys("results", &MS_SessionKey, &result);
 }
 
+int test_gssapi_anon(void)
+{
+    gss_ctx_id_t cli_ctx = GSS_C_NO_CONTEXT;
+    gss_ctx_id_t srv_ctx = GSS_C_NO_CONTEXT;
+    gss_buffer_desc cli_token = { 0 };
+    gss_buffer_desc srv_token = { 0 };
+    gss_buffer_desc ctx_token;
+    gss_cred_id_t cli_cred = GSS_C_NO_CREDENTIAL;
+    gss_cred_id_t srv_cred = GSS_C_NO_CREDENTIAL;
+    const char *srvname = "test@testserver";
+    gss_name_t gss_username = NULL;
+    gss_name_t gss_srvname = NULL;
+    gss_buffer_desc nbuf;
+    uint32_t retmin, retmaj;
+    const char *msg = "Sample, payload checking, message.";
+    gss_buffer_desc message = { strlen(msg), discard_const(msg) };
+    int ret;
+
+    setenv("NTLM_ALLOW_ANONYMOUS", "1", 1);
+
+    retmaj = gssntlm_import_name(&retmin, &nbuf,
+                                 GSS_C_NT_ANONYMOUS,
+                                 &gss_username);
+    if (retmaj != GSS_S_COMPLETE) {
+        print_gss_error("gssntlm_import_name(anonymous) failed!",
+                        retmaj, retmin);
+        return EINVAL;
+    }
+
+    nbuf.value = discard_const(srvname);
+    nbuf.length = strlen(srvname);
+    retmaj = gssntlm_import_name(&retmin, &nbuf,
+                                 GSS_C_NT_HOSTBASED_SERVICE,
+                                 &gss_srvname);
+    if (retmaj != GSS_S_COMPLETE) {
+        print_gss_error("gssntlm_import_name(srvname) failed!",
+                        retmaj, retmin);
+        return EINVAL;
+    }
+
+    retmaj = gssntlm_acquire_cred(&retmin, (gss_name_t)gss_srvname,
+                                  GSS_C_INDEFINITE, GSS_C_NO_OID_SET,
+                                  GSS_C_ACCEPT, &srv_cred, NULL, NULL);
+    if (retmaj != GSS_S_COMPLETE) {
+        print_gss_error("gssntlm_acquire_cred(srvname) failed!",
+                        retmaj, retmin);
+        ret = EINVAL;
+        goto done;
+    }
+
+    retmaj = gssntlm_init_sec_context(&retmin, cli_cred, &cli_ctx,
+                                      gss_srvname, GSS_C_NO_OID,
+                                      GSS_C_CONF_FLAG | GSS_C_INTEG_FLAG,
+                                      0, GSS_C_NO_CHANNEL_BINDINGS,
+                                      GSS_C_NO_BUFFER, NULL, &cli_token,
+                                      NULL, NULL);
+    if (retmaj != GSS_S_CONTINUE_NEEDED) {
+        print_gss_error("gssntlm_init_sec_context 1 failed!",
+                        retmaj, retmin);
+        ret = EINVAL;
+        goto done;
+    }
+
+    retmaj = gssntlm_accept_sec_context(&retmin, &srv_ctx, srv_cred,
+                                        &cli_token, GSS_C_NO_CHANNEL_BINDINGS,
+                                        NULL, NULL, &srv_token,
+                                        NULL, NULL, NULL);
+    if (retmaj != GSS_S_CONTINUE_NEEDED) {
+        print_gss_error("gssntlm_accept_sec_context 1 failed!",
+                        retmaj, retmin);
+        ret = EINVAL;
+        goto done;
+    }
+
+    gss_release_buffer(&retmin, &cli_token);
+
+    /* test importing and exporting context before it is fully estabished */
+    retmaj = gssntlm_export_sec_context(&retmin, &srv_ctx, &ctx_token);
+    if (retmaj != GSS_S_COMPLETE) {
+        print_gss_error("gssntlm_export_sec_context 1 failed!",
+                        retmaj, retmin);
+        ret = EINVAL;
+        goto done;
+    }
+    retmaj = gssntlm_import_sec_context(&retmin, &ctx_token, &srv_ctx);
+    if (retmaj != GSS_S_COMPLETE) {
+        print_gss_error("gssntlm_import_sec_context 1 failed!",
+                        retmaj, retmin);
+        ret = EINVAL;
+        goto done;
+    }
+    gss_release_buffer(&retmin, &ctx_token);
+
+    retmaj = gssntlm_init_sec_context(&retmin, cli_cred, &cli_ctx,
+                                      gss_srvname, GSS_C_NO_OID,
+                                      GSS_C_CONF_FLAG | GSS_C_INTEG_FLAG,
+                                      0, GSS_C_NO_CHANNEL_BINDINGS,
+                                      &srv_token, NULL, &cli_token,
+                                      NULL, NULL);
+    if (retmaj != GSS_S_COMPLETE) {
+        print_gss_error("gssntlm_init_sec_context 2 failed!",
+                        retmaj, retmin);
+        ret = EINVAL;
+        goto done;
+    }
+
+    gss_release_buffer(&retmin, &srv_token);
+
+    retmaj = gssntlm_accept_sec_context(&retmin, &srv_ctx, srv_cred,
+                                        &cli_token, GSS_C_NO_CHANNEL_BINDINGS,
+                                        NULL, NULL, &srv_token,
+                                        NULL, NULL, NULL);
+    if (retmaj != GSS_S_COMPLETE) {
+        print_gss_error("gssntlm_accept_sec_context 2 failed!",
+                        retmaj, retmin);
+        ret = EINVAL;
+        goto done;
+    }
+
+    gss_release_buffer(&retmin, &cli_token);
+    gss_release_buffer(&retmin, &srv_token);
+
+    /* test importing and exporting context after it is fully estabished */
+    retmaj = gssntlm_export_sec_context(&retmin, &cli_ctx, &ctx_token);
+    if (retmaj != GSS_S_COMPLETE) {
+        print_gss_error("gssntlm_export_sec_context 2 failed!",
+                        retmaj, retmin);
+        ret = EINVAL;
+        goto done;
+    }
+    retmaj = gssntlm_import_sec_context(&retmin, &ctx_token, &cli_ctx);
+    if (retmaj != GSS_S_COMPLETE) {
+        print_gss_error("gssntlm_import_sec_context 2 failed!",
+                        retmaj, retmin);
+        ret = EINVAL;
+        goto done;
+    }
+    gss_release_buffer(&retmin, &ctx_token);
+
+    retmaj = gssntlm_get_mic(&retmin, cli_ctx, 0, &message, &cli_token);
+    if (retmaj != GSS_S_COMPLETE) {
+        print_gss_error("gssntlm_get_mic(cli) failed!",
+                        retmaj, retmin);
+        ret = EINVAL;
+        goto done;
+    }
+
+    retmaj = gssntlm_verify_mic(&retmin, srv_ctx, &message, &cli_token, NULL);
+    if (retmaj != GSS_S_COMPLETE) {
+        print_gss_error("gssntlm_verify_mic(srv) failed!",
+                        retmaj, retmin);
+        ret = EINVAL;
+        goto done;
+    }
+
+    gss_release_buffer(&retmin, &cli_token);
+
+    retmaj = gssntlm_get_mic(&retmin, srv_ctx, 0, &message, &srv_token);
+    if (retmaj != GSS_S_COMPLETE) {
+        print_gss_error("gssntlm_get_mic(srv) failed!",
+                        retmaj, retmin);
+        ret = EINVAL;
+        goto done;
+    }
+
+    retmaj = gssntlm_verify_mic(&retmin, cli_ctx, &message, &srv_token, NULL);
+    if (retmaj != GSS_S_COMPLETE) {
+        print_gss_error("gssntlm_verify_mic(cli) failed!",
+                        retmaj, retmin);
+        ret = EINVAL;
+        goto done;
+    }
+
+    gss_release_buffer(&retmin, &srv_token);
+
+    retmaj = gssntlm_wrap(&retmin, cli_ctx, 1, 0, &message, NULL, &cli_token);
+    if (retmaj != GSS_S_COMPLETE) {
+        print_gss_error("gssntlm_wrap(cli) failed!",
+                        retmaj, retmin);
+        ret = EINVAL;
+        goto done;
+    }
+
+    retmaj = gssntlm_unwrap(&retmin, srv_ctx, &cli_token, &srv_token,
+                            NULL, NULL);
+    if (retmaj != GSS_S_COMPLETE) {
+        print_gss_error("gssntlm_unwrap(srv) failed!",
+                        retmaj, retmin);
+        ret = EINVAL;
+        goto done;
+    }
+
+    gss_release_buffer(&retmin, &cli_token);
+    gss_release_buffer(&retmin, &srv_token);
+
+    retmaj = gssntlm_wrap(&retmin, srv_ctx, 1, 0, &message, NULL, &srv_token);
+    if (retmaj != GSS_S_COMPLETE) {
+        print_gss_error("gssntlm_wrap(srv) failed!",
+                        retmaj, retmin);
+        ret = EINVAL;
+        goto done;
+    }
+
+    retmaj = gssntlm_unwrap(&retmin, cli_ctx, &srv_token, &cli_token,
+                            NULL, NULL);
+    if (retmaj != GSS_S_COMPLETE) {
+        print_gss_error("gssntlm_unwrap(cli) failed!",
+                        retmaj, retmin);
+        ret = EINVAL;
+        goto done;
+    }
+
+    if (memcmp(message.value, cli_token.value, cli_token.length) != 0) {
+        print_gss_error("sealing and unsealing failed to return the "
+                        "same result",
+                        retmaj, retmin);
+        ret = EINVAL;
+        goto done;
+    }
+
+    ret = 0;
+
+done:
+    gssntlm_delete_sec_context(&retmin, &cli_ctx, GSS_C_NO_BUFFER);
+    gssntlm_delete_sec_context(&retmin, &srv_ctx, GSS_C_NO_BUFFER);
+    gssntlm_release_name(&retmin, &gss_username);
+    gssntlm_release_name(&retmin, &gss_srvname);
+    gssntlm_release_cred(&retmin, &cli_cred);
+    gssntlm_release_cred(&retmin, &srv_cred);
+    gss_release_buffer(&retmin, &cli_token);
+    gss_release_buffer(&retmin, &srv_token);
+    return ret;
+}
+
 int main(int argc, const char *argv[])
 {
     struct ntlm_ctx *ctx;
@@ -2476,6 +2710,11 @@ int main(int argc, const char *argv[])
 
     fprintf(stderr, "Test ZERO LM_KEY\n");
     ret = test_ZERO_LMKEY(ctx);
+    fprintf(stderr, "Test: %s\n", (ret ? "FAIL":"SUCCESS"));
+    if (ret) gret++;
+
+    fprintf(stderr, "Test Anonymous Auth\n");
+    ret = test_gssapi_anon();
     fprintf(stderr, "Test: %s\n", (ret ? "FAIL":"SUCCESS"));
     if (ret) gret++;
 


### PR DESCRIPTION
Implements anonymous auth for initiators only, ie only the initiator can be anonymous, not the server.
Both client and server support this.

Resolves #9