### PR TITLE
Provide a zero lm key if the password is too long

### DIFF
--- a/src/ntlm_crypto.c
+++ b/src/ntlm_crypto.c
@@ -96,7 +96,10 @@ int LMOWFv1(const char *password, struct ntlm_key *result)
     if (result->length != 16) return EINVAL;
 
     len = strlen(password);
-    if (len > 14) return ERANGE;
+    if (len > 14) {
+        memset(result->data, 0, result->length);
+        return 0;
+    }
 
     out = 15;
     retstr = (char *)u8_toupper((const uint8_t *)password, len,


### PR DESCRIPTION
In Windows LM and NT keys are not geneated on the fly, but usually
stored in the Windows key store, therefore when LM generation fails or
is disable the LM Key is usually all zeros. Do the same here.

Fixes #23