### PR TITLE
Support get_sids request via private OID

### DIFF
--- a/src/external.c
+++ b/src/external.c
@@ -48,7 +48,9 @@ uint32_t external_srv_auth(struct gssntlm_ctx *ctx,
                            struct gssntlm_cred *cred,
                            struct ntlm_buffer *nt_chal_resp,
                            struct ntlm_buffer *lm_chal_resp,
-                           struct ntlm_key *session_base_key)
+                           struct ntlm_key *session_base_key,
+                           uint32_t *num_sids,
+                           ntlm_raw_sid *sids)
 {
 #if HAVE_WBCLIENT
     uint8_t challenge[8];
@@ -73,7 +75,7 @@ uint32_t external_srv_auth(struct gssntlm_ctx *ctx,
     return winbind_srv_auth(cred->cred.external.user.data.user.name,
                             cred->cred.external.user.data.user.domain,
                             ctx->workstation, chal_ptr,
-                            nt_chal_resp, lm_chal_resp, session_base_key);
+                            nt_chal_resp, lm_chal_resp, session_base_key, num_sids, sids);
 #else
     return ERR_NOTAVAIL;
 #endif

--- a/src/gss_auth.c
+++ b/src/gss_auth.c
@@ -310,7 +310,9 @@ uint32_t gssntlm_srv_auth(uint32_t *minor_status,
                           struct gssntlm_cred *cred,
                           struct ntlm_buffer *nt_chal_resp,
                           struct ntlm_buffer *lm_chal_resp,
-                          struct ntlm_key *key_exchange_key)
+                          struct ntlm_key *key_exchange_key,
+                          uint32_t *num_sids,
+                          ntlm_raw_sid *sids)
 {
     struct ntlm_key session_base_key = { .length = 16 };
     struct ntlm_key ntlmv2_key = { .length = 16 };
@@ -415,7 +417,7 @@ uint32_t gssntlm_srv_auth(uint32_t *minor_status,
 
     case GSSNTLM_CRED_EXTERNAL:
         retmin = external_srv_auth(ctx, cred, nt_chal_resp, lm_chal_resp,
-                                   &session_base_key);
+                                   &session_base_key, num_sids, sids);
         if (retmin) {
             set_GSSERR(retmin);
             goto done;

--- a/src/gss_ntlmssp.h
+++ b/src/gss_ntlmssp.h
@@ -124,6 +124,8 @@ struct gssntlm_ctx {
 
     struct ntlm_key exported_session_key;
     struct ntlm_signseal_state crypto_state;
+    uint32_t num_sids;
+    ntlm_raw_sid sids[MAX_SIDS_COUNT];
 
     uint32_t int_flags;
     time_t expiration_time;
@@ -179,7 +181,9 @@ uint32_t external_srv_auth(struct gssntlm_ctx *ctx,
                            struct gssntlm_cred *cred,
                            struct ntlm_buffer *nt_chal_resp,
                            struct ntlm_buffer *lm_chal_resp,
-                           struct ntlm_key *session_base_key);
+                           struct ntlm_key *session_base_key,
+                           uint32_t *num_sids,
+                           ntlm_raw_sid *sids);
 
 uint32_t netbios_get_names(char *computer_name,
                            char **netbios_host, char **netbios_domain);
@@ -197,7 +201,9 @@ uint32_t gssntlm_srv_auth(uint32_t *minor,
                           struct gssntlm_cred *cred,
                           struct ntlm_buffer *nt_chal_resp,
                           struct ntlm_buffer *lm_chal_resp,
-                          struct ntlm_key *key_exchange_key);
+                          struct ntlm_key *key_exchange_key,
+                          uint32_t *num_sids,
+                          ntlm_raw_sid *sids);
 
 extern const gss_OID_desc gssntlm_oid;
 

--- a/src/gss_ntlmssp_winbind.h
+++ b/src/gss_ntlmssp_winbind.h
@@ -17,4 +17,6 @@ uint32_t winbind_srv_auth(char *user, char *domain,
                           char *workstation, uint8_t *challenge,
                           struct ntlm_buffer *nt_chal_resp,
                           struct ntlm_buffer *lm_chal_resp,
-                          struct ntlm_key *ntlmv2_key);
+                          struct ntlm_key *ntlmv2_key,
+                          uint32_t *num_sids,
+                          ntlm_raw_sid *sids);

--- a/src/gssapi_ntlmssp.h
+++ b/src/gssapi_ntlmssp.h
@@ -53,6 +53,17 @@ extern "C" {
 #define GSS_NTLMSSP_RESET_CRYPTO_OID_STRING GSS_NTLMSSP_BASE_OID_STRING "\x03"
 #define GSS_NTLMSSP_RESET_CRYPTO_OID_LENGTH GSS_NTLMSSP_BASE_OID_LENGTH + 1
 
+/* NTLM Get SIDs OID
+ * OID to be used with gss_inquire_sec_context_by_oid()
+ * to get buffer with a list of user's raw SIDs
+ * as reported by authentication process.
+ * MS-PAC used for Kerberos is not fully available with NTLM
+ * so this is the way of getting details for user.
+ */
+
+#define GSS_NTLMSSP_GET_SIDS_OID_STRING GSS_NTLMSSP_BASE_OID_STRING "\x04"
+#define GSS_NTLMSSP_GET_SIDS_OID_LENGTH GSS_NTLMSSP_BASE_OID_LENGTH + 1
+
 #define GSS_NTLMSSP_CS_DOMAIN "ntlmssp_domain"
 #define GSS_NTLMSSP_CS_NTHASH "ntlmssp_nthash"
 #define GSS_NTLMSSP_CS_PASSWORD "ntlmssp_password"

--- a/src/ntlm.h
+++ b/src/ntlm.h
@@ -128,6 +128,9 @@ struct ntlm_signseal_state {
     bool ext_sec;
 };
 
+#define MAX_SIDS_COUNT 256
+typedef char ntlm_raw_sid[68]; /* Max size of SID is 68 bytes */
+
 #define NTLM_SEND 1
 #define NTLM_RECV 2
 


### PR DESCRIPTION
To allow server to get details about authenticated user
new get_sid request by OID is implemented to report the list
of user SIDs. The list of SIDs is stored in gssntlm context
in raw representation and can be requested
by gss_inquire_sec_context_by_oid() call

Signed-off-by: Volodymyr Khomenko <volodymyr@vastdata.com>