### PR TITLE
Do not require cached users with winbind

### DIFF
--- a/src/gss_ntlmssp.h
+++ b/src/gss_ntlmssp.h
@@ -97,6 +97,7 @@ struct gssntlm_cred {
         } server;
         struct {
             struct gssntlm_name user;
+            bool creds_in_cache;
         } external;
     } cred;
 };

--- a/src/gss_sec_ctx.c
+++ b/src/gss_sec_ctx.c
@@ -96,6 +96,11 @@ uint32_t gssntlm_init_sec_context(uint32_t *minor_status,
             set_GSSERRS(ERR_NOARG, GSS_S_CRED_UNAVAIL);
             goto done;
         }
+        if (cred->type == GSSNTLM_CRED_EXTERNAL &&
+            cred->cred.external.creds_in_cache == 0) {
+            set_GSSERRS(ERR_NOARG, GSS_S_CRED_UNAVAIL);
+            goto done;
+        }
     }
 
     if (ctx == NULL) {

--- a/src/gss_serialize.c
+++ b/src/gss_serialize.c
@@ -785,12 +785,13 @@ done:
 
 #pragma pack(push, 1)
 struct export_cred {
-    uint16_t version;    /* 0x00 0x01 */
+    uint16_t version;    /* 0x00 0x02 */
     uint16_t type;
 
     struct export_name name;    /* user or server name */
     struct relmem nt_hash;      /* empty for dummy or server */
     struct relmem lm_hash;      /* empty for dummy or server */
+    uint8_t ext_cached;
 
     uint8_t data[];
 };
@@ -886,7 +887,11 @@ uint32_t gssntlm_export_cred(uint32_t *minor_status,
             set_GSSERR(ret);
             goto done;
         }
+        if (cred->cred.external.creds_in_cache) {
+            ecred->ext_cached = 1;
+        }
         break;
+
     }
 
     set_GSSERRS(0, GSS_S_COMPLETE);
@@ -981,6 +986,7 @@ uint32_t gssntlm_import_cred(uint32_t *minor_status,
         retmaj = import_name(&retmin, &state, &ecred->name,
                           &cred->cred.external.user);
         if (retmaj != GSS_S_COMPLETE) goto done;
+        cred->cred.external.creds_in_cache = (ecred->ext_cached == 1);
         break;
     default:
         set_GSSERRS(ERR_BADARG, GSS_S_DEFECTIVE_TOKEN);

--- a/src/winbind.c
+++ b/src/winbind.c
@@ -55,6 +55,7 @@ uint32_t winbind_get_creds(struct gssntlm_name *name,
     struct wbcCredentialCacheInfo *result;
     struct wbcInterfaceDetails *details = NULL;
     wbcErr wbc_status;
+    bool cached = false;
     int ret = ERR_NOTAVAIL;
 
     if (name && name->data.user.domain) {
@@ -81,9 +82,10 @@ uint32_t winbind_get_creds(struct gssntlm_name *name,
     params.blobs = NULL;
     wbc_status = wbcCredentialCache(&params, &result, NULL);
 
-    if(!WBC_ERROR_IS_OK(wbc_status)) goto done;
-
-    /* Yes, winbind seems to think it has credentials for us */
+    if (WBC_ERROR_IS_OK(wbc_status)) {
+        /* Yes, winbind seems to think it has credentials for us */
+        cached = true;
+    }
     wbcFreeMemory(result);
 
     cred->type = GSSNTLM_CRED_EXTERNAL;
@@ -98,6 +100,8 @@ uint32_t winbind_get_creds(struct gssntlm_name *name,
         ret = ENOMEM;
         goto done;
     }
+
+    cred->cred.external.creds_in_cache = cached;
 
     ret = 0;
 


### PR DESCRIPTION
When acquiring credentials we may need to know if a cache is available.
This is necessary in the ISC cacse as we need to use those cached
credentials to perform NTLM authentication. However in the server case
we do not need creds of the user to be cached, all we need is a handle
that can be used to later authenticated the user against a DC.

Fixes #32 