### PR TITLE
Fixed memleak of temporary usr_cred in gssntlm_accept_sec_context

### DIFF
--- a/src/gss_sec_ctx.c
+++ b/src/gss_sec_ctx.c
@@ -992,6 +992,7 @@ done:
     }
     *context_handle = (gss_ctx_id_t)ctx;
     gssntlm_release_name(&tmpmin, (gss_name_t *)&server_name);
+    gssntlm_release_cred(&tmpmin, (gss_cred_id_t *)&usr_cred);
     safefree(computer_name);
     safefree(nb_computer_name);
     safefree(nb_domain_name);


### PR DESCRIPTION
Memleak of temporary usr_cred in gssntlm_accept_sec_context (used for 2nd pass)

Signed-off-by: Volodymyr Khomenko <volodymyr@vastdata.com>