### PR TITLE
Add ability to pass keyfile via cred store

### DIFF
--- a/src/gss_ntlmssp.h
+++ b/src/gss_ntlmssp.h
@@ -79,6 +79,7 @@ struct gssntlm_cred {
         } user;
         struct {
             struct gssntlm_name name;
+            char *keyfile;
         } server;
         struct {
             struct gssntlm_name user;

--- a/src/gssapi_ntlmssp.h
+++ b/src/gssapi_ntlmssp.h
@@ -56,6 +56,7 @@ extern "C" {
 #define GSS_NTLMSSP_CS_DOMAIN "ntlmssp_domain"
 #define GSS_NTLMSSP_CS_NTHASH "ntlmssp_nthash"
 #define GSS_NTLMSSP_CS_PASSWORD "ntlmssp_password"
+#define GSS_NTLMSSP_CS_KEYFILE "ntlmssp_keyfile"
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This works both for ISC and ASC, so a user can pass their own keyfile
with a single entry or a server can be passed a keyfile with all users'
entries.