### PR TITLE
Support get_sids request via name attributes

### DIFF
--- a/src/external.c
+++ b/src/external.c
@@ -73,7 +73,8 @@ uint32_t external_srv_auth(struct gssntlm_ctx *ctx,
     return winbind_srv_auth(cred->cred.external.user.data.user.name,
                             cred->cred.external.user.data.user.domain,
                             ctx->workstation, chal_ptr,
-                            nt_chal_resp, lm_chal_resp, session_base_key);
+                            nt_chal_resp, lm_chal_resp, session_base_key,
+                            &ctx->source_name.attrs);
 #else
     return ERR_NOTAVAIL;
 #endif

--- a/src/gss_ntlmssp_winbind.h
+++ b/src/gss_ntlmssp_winbind.h
@@ -17,4 +17,5 @@ uint32_t winbind_srv_auth(char *user, char *domain,
                           char *workstation, uint8_t *challenge,
                           struct ntlm_buffer *nt_chal_resp,
                           struct ntlm_buffer *lm_chal_resp,
-                          struct ntlm_key *ntlmv2_key);
+                          struct ntlm_key *ntlmv2_key,
+                          struct gssntlm_name_attribute **auth_attrs);

--- a/src/gss_spi.c
+++ b/src/gss_spi.c
@@ -147,6 +147,18 @@ OM_uint32 gss_release_name(OM_uint32 *minor_status,
     return gssntlm_release_name(minor_status,
                                 input_name);
 }
+OM_uint32 gss_get_name_attribute(OM_uint32 *minor_status,
+                                 gss_name_t name,
+                                 gss_buffer_t attr,
+                                 int *authenticated,
+                                 int *complete,
+                                 gss_buffer_t value,
+                                 gss_buffer_t display_value,
+                                 int *more)
+{
+    return gssntlm_get_name_attribute(minor_status, name, attr, authenticated,
+                                      complete, value, display_value, more);
+}
 
 OM_uint32 gss_context_time(OM_uint32 *minor_status,
                            gss_ctx_id_t context_handle,


### PR DESCRIPTION
To allow server to get details about authenticated user
new get_sid request by "urn:gssntlmssp:sids" name attribute
is implemented (see RFC6680) to report the list of user SIDs.
The list of SIDs is stored in gssntlm source_name
(part of gss context, can be get by gss_inquire_context)
in textual representation - comma-separated list of SIDs.
gss_get_name_attribute() and gssntlm_inquire_name()
should be used to inquire name attributes.

See previous discussion here: https://github.com/gssapi/gss-ntlmssp/pull/31

Signed-off-by: Volodymyr Khomenko <volodymyr@vastdata.com>