### PR TITLE
Export name attrs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -157,21 +157,6 @@ installgssntlmsspdirs::
     $(DESTDIR)$(libdir)/gssntlmssp \
     $(DESTDIR)$(mandir)
 
-if HAVE_DOXYGEN
-docs:
-	$(DOXYGEN) doxy.config
-else
-docs:
-	@echo "Doxygen not installed, cannot generate documentation"
-	@exit 1
-endif
-
-install-exec-hook: installgssntlmsspdirs
-	mkdir -p doc $(DESTDIR)/$(docdir); cp -a doc $(DESTDIR)/$(docdir)/
-
-clean-local:
-	rm -Rf doc
-
 CLEANFILES = *.X */*.X */*/*.X
 
 tests: all $(check_PROGRAMS)

--- a/src/gss_ntlmssp.h
+++ b/src/gss_ntlmssp.h
@@ -41,9 +41,7 @@
 #define NTLMSSP_CTX_FLAG_AUTH_WITH_MIC  0x04 /* Auth MIC was created */
 
 struct gssntlm_name_attribute {
-    const char *attr_name; /* Read-only static string, should not be released */
-                           /* NULL is used to indicate         */
-                           /* the terminating element of array */
+    char *attr_name; /* NULL indicates array termination */
     gss_buffer_desc attr_value;
 };
 


### PR DESCRIPTION
Adjust code to cope with the existence on name attributes in names, which needs to be exported when exporting contexts and credentials

@kvv81 unfortunately the requirement to be able to export/import data forced me to allocate attribute names. Please checkout the first commit.

@frozencemetery PTAL