### PR TITLE
Use thread local storage for winbind context

### DIFF
--- a/conf_macros.m4
+++ b/conf_macros.m4
@@ -85,3 +85,20 @@ AC_DEFUN([WITH_WBCLIENT],
 
           AM_CONDITIONAL([BUILD_WBCLIENT], [test x"$with_wbclient" = xyes])
          ])
+
+AC_DEFUN([WITH_WINBIND_TLS_CONTEXT],
+         [
+          AC_ARG_WITH([winbind-tls-context],
+                      [AC_HELP_STRING([--with-winbind-tls-context],
+                                      [Whether to default to thread local storage for winbind contexts [no]])
+                      ],
+                      [with_winbind_tls_context=$withval],
+                      with_winbind_tls_context=no)
+
+         if test x"$with_winbind_tls_context" = xyes; then
+             AC_DEFINE(DEFAULT_WB_TLS_CTX, 1,
+                       [whether to default to thread local storage for winbind contexts S])
+         fi
+         AM_CONDITIONAL([DEFAULT_WB_TLS_CTX], [test x"$with_winbind_tls_context" = xyes])
+        ])
+

--- a/configure.ac
+++ b/configure.ac
@@ -53,6 +53,7 @@ WITH_TEST_DIR
 WITH_MANPAGES
 WITH_XML_CATALOG
 WITH_WBCLIENT
+WITH_WINBIND_TLS_CONTEXT
 
 m4_include([external/pkg.m4])
 m4_include([external/docbook.m4])

--- a/src/gss_creds.c
+++ b/src/gss_creds.c
@@ -401,6 +401,7 @@ void gssntlm_int_release_cred(struct gssntlm_cred *cred)
 }
 
 uint32_t gssntlm_acquire_cred_from(uint32_t *minor_status,
+                                   void *external_context,
                                    gss_name_t desired_name,
                                    uint32_t time_req,
                                    gss_OID_set desired_mechs,
@@ -464,7 +465,7 @@ uint32_t gssntlm_acquire_cred_from(uint32_t *minor_status,
             }
             if (retmin) {
                 uint32_t ret;
-                ret = external_get_creds(name, cred);
+                ret = external_get_creds(external_context, name, cred);
                 if (ret != ERR_NOTAVAIL) {
                     retmin = ret;
                 }
@@ -520,7 +521,7 @@ uint32_t gssntlm_acquire_cred(uint32_t *minor_status,
                               gss_OID_set *actual_mechs,
                               uint32_t *time_rec)
 {
-    return gssntlm_acquire_cred_from(minor_status,
+    return gssntlm_acquire_cred_from(minor_status, NULL,
                                      desired_name,
                                      time_req,
                                      desired_mechs,
@@ -563,7 +564,7 @@ uint32_t gssntlm_acquire_cred_with_password(uint32_t *minor_status,
     cred_store.count = 1;
     cred_store.elements = &element;
 
-    return gssntlm_acquire_cred_from(minor_status,
+    return gssntlm_acquire_cred_from(minor_status, NULL,
                                      desired_name,
                                      time_req,
                                      desired_mechs,
@@ -586,7 +587,7 @@ uint32_t gssntlm_inquire_cred(uint32_t *minor_status,
     uint32_t maj, min;
 
     if (cred_handle == GSS_C_NO_CREDENTIAL) {
-        maj = gssntlm_acquire_cred_from(&min,
+        maj = gssntlm_acquire_cred_from(&min, NULL,
                                         NULL, GSS_C_INDEFINITE,
                                         NULL, GSS_C_INITIATE,
                                         GSS_C_NO_CRED_STORE,

--- a/src/gss_names.c
+++ b/src/gss_names.c
@@ -713,7 +713,7 @@ done:
     return GSSERR();
 }
 
-uint32_t netbios_get_names(char *computer_name,
+uint32_t netbios_get_names(void *ctx, char *computer_name,
                            char **netbios_host, char **netbios_domain)
 {
     char *nb_computer_name = NULL;
@@ -741,7 +741,7 @@ uint32_t netbios_get_names(char *computer_name,
 
     if (!nb_computer_name || !nb_domain_name) {
         /* fetch only mising ones */
-        ret = external_netbios_get_names(
+        ret = external_netbios_get_names(ctx,
                     nb_computer_name ? NULL : &nb_computer_name,
                     nb_domain_name ? NULL : &nb_domain_name);
         if ((ret != 0) &&

--- a/src/gss_ntlmssp.h
+++ b/src/gss_ntlmssp.h
@@ -136,6 +136,8 @@ struct gssntlm_ctx {
 
     uint32_t int_flags;
     time_t expiration_time;
+
+    void *external_context;
 };
 
 #define set_GSSERRS(min, maj) \
@@ -189,8 +191,11 @@ void gssntlm_release_attrs(struct gssntlm_name_attribute **attrs);
 int gssntlm_copy_name(struct gssntlm_name *src, struct gssntlm_name *dst);
 int gssntlm_copy_creds(struct gssntlm_cred *in, struct gssntlm_cred *out);
 
-uint32_t external_netbios_get_names(char **computer, char **domain);
-uint32_t external_get_creds(struct gssntlm_name *name,
+void *external_get_context(void);
+void external_free_context(void *ctx);
+uint32_t external_netbios_get_names(void *ctx, char **computer, char **domain);
+uint32_t external_get_creds(void *ctx,
+                            struct gssntlm_name *name,
                             struct gssntlm_cred *cred);
 uint32_t external_cli_auth(struct gssntlm_ctx *ctx,
                            struct gssntlm_cred *cred,
@@ -202,7 +207,7 @@ uint32_t external_srv_auth(struct gssntlm_ctx *ctx,
                            struct ntlm_buffer *lm_chal_resp,
                            struct ntlm_key *session_base_key);
 
-uint32_t netbios_get_names(char *computer_name,
+uint32_t netbios_get_names(void *ctx, char *computer_name,
                            char **netbios_host, char **netbios_domain);
 
 bool is_ntlm_v1(struct ntlm_buffer *nt_chal_resp);
@@ -232,6 +237,7 @@ uint32_t gssntlm_acquire_cred(uint32_t *minor_status,
                               uint32_t *time_rec);
 
 uint32_t gssntlm_acquire_cred_from(uint32_t *minor_status,
+                                   void *external_context,
                                    gss_name_t desired_name,
                                    uint32_t time_req,
                                    gss_OID_set desired_mechs,

--- a/src/gss_ntlmssp_winbind.h
+++ b/src/gss_ntlmssp_winbind.h
@@ -1,11 +1,15 @@
 /* Copyright (C) 2014 GSS-NTLMSSP contributors, see COPYING for License */
 
-uint32_t winbind_get_names(char **computer, char **domain);
+void *winbind_get_context(void);
+void winbind_free_context(void *ectx);
 
-uint32_t winbind_get_creds(struct gssntlm_name *name,
+uint32_t winbind_get_names(void *ectx, char **computer, char **domain);
+
+uint32_t winbind_get_creds(void *ectx,
+                           struct gssntlm_name *name,
                            struct gssntlm_cred *cred);
 
-uint32_t winbind_cli_auth(char *user, char *domain,
+uint32_t winbind_cli_auth(void *ectx, char *user, char *domain,
                           gss_channel_bindings_t input_chan_bindings,
                           uint32_t in_flags,
                           uint32_t *neg_flags,
@@ -13,7 +17,8 @@ uint32_t winbind_cli_auth(char *user, char *domain,
                           struct ntlm_buffer *chal_msg,
                           struct ntlm_buffer *auth_msg,
                           struct ntlm_key *exported_session_key);
-uint32_t winbind_srv_auth(char *user, char *domain,
+
+uint32_t winbind_srv_auth(void *ectx, char *user, char *domain,
                           char *workstation, uint8_t *challenge,
                           struct ntlm_buffer *nt_chal_resp,
                           struct ntlm_buffer *lm_chal_resp,

--- a/src/gss_spi.c
+++ b/src/gss_spi.c
@@ -53,7 +53,7 @@ OM_uint32 gss_acquire_cred_from(OM_uint32 *minor_status,
                                 gss_OID_set *actual_mechs,
                                 OM_uint32 *time_rec)
 {
-    return gssntlm_acquire_cred_from(minor_status,
+    return gssntlm_acquire_cred_from(minor_status, NULL,
                                      desired_name,
                                      time_req,
                                      desired_mechs,

--- a/tests/ntlmssptest.c
+++ b/tests/ntlmssptest.c
@@ -1513,7 +1513,8 @@ int test_gssapi_1(bool user_env_file, bool use_cb, bool no_seal, bool use_cs)
     }
 
     if (user_env_file || use_cs) {
-        retmaj = gssntlm_acquire_cred_from(&retmin, (gss_name_t)gss_username,
+        retmaj = gssntlm_acquire_cred_from(&retmin, NULL,
+                                           (gss_name_t)gss_username,
                                            GSS_C_INDEFINITE, GSS_C_NO_OID_SET,
                                            GSS_C_INITIATE, cred_store,
                                            &cli_cred, NULL, NULL);
@@ -1560,7 +1561,8 @@ int test_gssapi_1(bool user_env_file, bool use_cb, bool no_seal, bool use_cs)
         return EINVAL;
     }
 
-    retmaj = gssntlm_acquire_cred_from(&retmin, (gss_name_t)gss_srvname,
+    retmaj = gssntlm_acquire_cred_from(&retmin, NULL,
+                                       (gss_name_t)gss_srvname,
                                        GSS_C_INDEFINITE, GSS_C_NO_OID_SET,
                                        GSS_C_ACCEPT, cred_store,
                                        &srv_cred, NULL, NULL);
@@ -2684,7 +2686,7 @@ int test_ACQ_NO_NAME(void)
     uint32_t retmin, retmaj;
     int ret;
 
-    retmaj = gssntlm_acquire_cred_from(&retmin, GSS_C_NO_NAME,
+    retmaj = gssntlm_acquire_cred_from(&retmin, NULL, GSS_C_NO_NAME,
                                        GSS_C_INDEFINITE, GSS_C_NO_OID_SET,
                                        GSS_C_INITIATE, &cred_store,
                                        &cli_cred, NULL, NULL);


### PR DESCRIPTION
This allow multiple calls into winbindd from parallel threads without
suffering from a common mutex that serializaes all authentications.

The price to pay is that a new context is allocated for each thread, and
the way windbind works, this probably mean a separate file descriptor is
created for each of this thread.

The users of gssntlmssp in a multi-threaded environemnt will need to be
carufl to limit the number of threads they allow to use gssapi in this
case.

Resolves #46