### PR TITLE
make HOST_NAME_MAX an alias of MAXHOSTNAMELEN

### DIFF
--- a/src/gss_names.c
+++ b/src/gss_names.c
@@ -17,6 +17,11 @@
 
 #include "gss_ntlmssp.h"
 
+#ifndef	HOST_NAME_MAX
+#include <sys/param.h>
+#define	HOST_NAME_MAX	MAXHOSTNAMELEN
+#endif
+
 static uint32_t string_split(uint32_t *minor_status, char sep,
                              const char *str, size_t len,
                              char **s1, char **s2)


### PR DESCRIPTION
HOST_NAME_MAX is not available on Solaris/*BSD systems. However we
can use MAXHOSTNAMELEN on those platforms instead.