### PR TITLE
let automake to use correct libdir, when building ntlmssptest

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -129,10 +129,11 @@ ntlmssptest_SOURCES = \
 ntlmssptest_CFLAGS = \
     $(WBC_CFLAGS) \
     $(AM_CFLAGS)
+ntlmssptest_LDFLAGS = \
+    -L$(libdir)
 ntlmssptest_LDADD = \
-    $(WBC_LIBS) \
-    $(GSSAPI_LIBS) \
-    $(CRYPTO_LIBS)
+    $(GN_MECHGLUE_LIBS) \
+    $(UNISTRING_LIBS)
 
 dist_noinst_DATA += \
     m4

--- a/configure.ac
+++ b/configure.ac
@@ -94,6 +94,8 @@ AC_CHECK_LIB(unistring, u8_toupper,,
              [AC_MSG_ERROR([libunistring does not support u8_toupper])],
              [$UNISTRING_LIBS])
 
+AC_SUBST([UNISTRING_LIBS])
+
 AX_CHECK_OPENSSL(,[AC_MSG_ERROR([Could not find OpenSSL support])])
 
 CRYPTO_LIBS="$OPENSSL_LIBS"


### PR DESCRIPTION
We build 32-bit and 64-bit version of gss-ntlmssp. Each version is
configured with its own --libdir location to pickup correct shared
libraries. Command here configures 32-bit verson:

```
./configure --prefix=/usr \
	--mandir=/usr/share/man \
	--bindir=/usr/bin \
	--sbindir=/usr/sbin \
	--libdir=/usr/lib/ \
	--with-wbclient=no \
	--disable-dependency-tracking
```
this is configure comand for 64-bit version:
```
./configure --prefix=/usr \
	--mandir=/usr/share/man \
	--bindir=/usr/bin \
	--sbindir=/usr/sbin \
	--libdir=/usr/lib/amd64 \
	--with-wbclient=no \
	--disable-dependency-tracking
```

However linker fails to pick up correct location of libunistring, when
build 64-bit version.

The most important chancge in this pull request is introduction
of:

```
ntlmssptest_LDFLAGS = \
    -L$(libdir)
```

The other changes are just matter of taste as I want to make check
for libunistring dependency more obvious.