### PR TITLE
gssntlmssp_la_LDFLAGS also requires libdir to pick up right libraries…

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -119,6 +119,7 @@ gssntlmssp_la_CFLAGS = \
     $(WBC_CFLAGS) \
     $(AM_CFLAGS)
 gssntlmssp_la_LDFLAGS = \
+    -L$(libdir) \
     $(GN_MECHGLUE_LIBS) \
     -export-symbols-regex '^gss(spi|)_' \
     -avoid-version \


### PR DESCRIPTION
… (64-bit vs 32-bit)

without this diff 64-bit build completes with warning below:
```
libtool: link:  /usr/gcc/10/bin/gcc -shared  -fPIC -DPIC -Wl,-z -Wl,text -Wl,-M -Wl,.libs/gssntlmssp.so.exp -Wl,-h -Wl,gssntlmssp.so -o .libs/gssntlmssp.so  src/.libs/gssntlmssp_la-crypto.o src/.libs/gssntlmssp_la-ntlm_crypto.o src/.libs/gssntlmssp_la-ntlm.o src/.libs/gssntlmssp_la-debug.o src/.libs/gssntlmssp_la-gss_err.o src/.libs/gssntlmssp_la-gss_spi.o src/.libs/gssntlmssp_la-gss_names.o src/.libs/gssntlmssp_la-gss_creds.o src/.libs/gssntlmssp_la-gss_sec_ctx.o src/.libs/gssntlmssp_la-gss_signseal.o src/.libs/gssntlmssp_la-gss_serialize.o src/.libs/gssntlmssp_la-external.o src/.libs/gssntlmssp_la-gss_auth.o src/.libs/gssntlmssp_la-gss_ntlmssp.o   -lkrb5 -lk5crypto -lcom_err -lssl -lcrypto -L/usr/lib -lz -lunistring -lgssapi_krb5  -m64 -O0 -m64 -pthreads -m64 -O0   -pthreads
ld: warning: file /usr/lib/libunistring.a(locale-language.o): wrong ELF class: ELFCLASS32
libtool: link: rm -f .libs/gssntlmssp.so.exp
libtool: link: ( cd ".libs" && rm -f "gssntlmssp.la" && ln -s "../gssntlmssp.la" "gssntlmssp.la" )
make[3]: Leaving directory '/export/home/sashan/userland/components/gss-ntlmssp/build/amd64'
make[2]: Leaving directory '/export/home/sashan/userland/components/gss-ntlmssp/build/amd64'
make[1]: Leaving directory '/export/home/sashan/userland/components/gss-ntlmssp/build/amd64'
/usr/bin/touch /export/home/sashan/userland/components/gss-ntlmssp/build/amd64/.built
```

the resulting plugin fails to load due to missing symbol `u8_conv_to_encoding`,
which is supposed to be provided by `usr/lib/libunistring.a`