### PR TITLE
DRAFT: Add gssspi_mech_invoke method to turn on debugging

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -1,33 +1,123 @@
 /* Copyright (C) 2014 GSS-NTLMSSP contributors, see COPYING for license */
 
 #define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <pthread.h>
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
 
+#include "gssapi_ntlmssp.h"
+
+#define OPEN_FLAGS O_WRONLY | O_CREAT | O_APPEND| O_CLOEXEC
+#define discard_const(ptr) ((void *)((uintptr_t)(ptr)))
+
+static pthread_mutex_t debug_mutex = PTHREAD_MUTEX_INITIALIZER;
 bool gssntlm_debug_initialized = false;
-bool gssntlm_debug_enabled = false;
-static FILE *debug_fd = NULL;
+int gssntlm_debug_fd = -1;
 
 void gssntlm_debug_init(void)
 {
     char *env;
 
+    if (gssntlm_debug_initialized) return;
+
+    pthread_mutex_lock(&debug_mutex);
+
     env = secure_getenv("GSSNTLMSSP_DEBUG");
     if (env) {
-        debug_fd = fopen(env, "a");
-        if (debug_fd) gssntlm_debug_enabled = true;
+        gssntlm_debug_fd = open(env, OPEN_FLAGS, 0660);
     }
     gssntlm_debug_initialized = true;
+
+    pthread_mutex_unlock(&debug_mutex);
 }
 
 void gssntlm_debug_printf(const char *fmt, ...)
 {
     va_list ap;
 
+    if (gssntlm_debug_fd == -1) return;
+
     va_start(ap, fmt);
-    vfprintf(debug_fd, fmt, ap);
+    vdprintf(gssntlm_debug_fd, fmt, ap);
     va_end(ap);
-    fflush(debug_fd);
+    fdatasync(gssntlm_debug_fd);
+}
+
+static int gssntlm_debug_enable(const char *filename)
+{
+    int old_debug_fd = gssntlm_debug_fd;
+    int new_debug_fd = -1;
+    int ret = 0;
+
+    pthread_mutex_lock(&debug_mutex);
+
+    gssntlm_debug_initialized = true;
+
+    new_debug_fd = open(filename, OPEN_FLAGS, 0660);
+    if (new_debug_fd == -1) {
+        ret = errno;
+    }
+
+    gssntlm_debug_fd = new_debug_fd;
+
+    if (old_debug_fd != -1) {
+        close(old_debug_fd);
+    }
+
+    pthread_mutex_unlock(&debug_mutex);
+
+    return ret;
+}
+
+static int gssntlm_debug_disable(void)
+{
+    int old_debug_fd = gssntlm_debug_fd;
+    int ret = 0;
+
+    pthread_mutex_lock(&debug_mutex);
+
+    gssntlm_debug_fd = -1;
+
+    if (old_debug_fd != -1) {
+        ret = close(old_debug_fd);
+    }
+
+    pthread_mutex_unlock(&debug_mutex);
+
+    return ret;
+}
+
+gss_OID_desc gssntlm_debug_oid = {
+    GSS_NTLMSSP_DEBUG_OID_LENGTH,
+    discard_const(GSS_NTLMSSP_DEBUG_OID_STRING)
+};
+
+int gssntlm_debug_invoke(gss_buffer_t value)
+{
+    char filename[PATH_MAX] = { 0 };
+
+    if (value->length > PATH_MAX - 1) {
+        return EINVAL;
+    }
+
+    if ((value->length != 0) &&
+        (((char *)value->value)[0] != '\0')) {
+        memcpy(filename, value->value, value->length);
+        filename[value->length] = '\0';
+    }
+
+    if (filename[0] == '\0') {
+        return gssntlm_debug_disable();
+    }
+
+    return gssntlm_debug_enable(filename);
 }

--- a/src/debug.h
+++ b/src/debug.h
@@ -6,8 +6,9 @@
 #include <stdbool.h>
 #include <time.h>
 
+extern gss_OID_desc gssntlm_debug_oid;
 extern bool gssntlm_debug_initialized;
-extern bool gssntlm_debug_enabled;
+extern int gssntlm_debug_fd;
 
 void gssntlm_debug_init(void);
 void gssntlm_debug_printf(const char *fmt, ...);
@@ -23,7 +24,7 @@ static inline int debug_gss_errors(const char *function,
     if (unlikely(gssntlm_debug_initialized == false)) {
         gssntlm_debug_init();
     }
-    if (unlikely(gssntlm_debug_enabled == true)) {
+    if (unlikely(gssntlm_debug_fd != -1)) {
         gssntlm_debug_printf("[%ld] %s: %s() @ %s:%u [%u:%u]\n",
                              (long)time(NULL),
                              GSS_ERROR(maj) ? "ERROR" : "ALLOK",
@@ -33,5 +34,7 @@ static inline int debug_gss_errors(const char *function,
 }
 #define DEBUG_GSS_ERRORS(maj, min) \
     debug_gss_errors(__FUNCTION__, __FILE__, __LINE__, maj, min)
+
+int gssntlm_debug_invoke(gss_buffer_t value);
 
 #endif /* _GSSNTLMSSP_DEBUG_H_ */

--- a/src/gss_ntlmssp.c
+++ b/src/gss_ntlmssp.c
@@ -178,3 +178,36 @@ int gssntlm_get_lm_compatibility_level(void)
     /* use 3 by default for better compatibility */
     return 3;
 }
+
+uint32_t gssntlm_mech_invoke(uint32_t *minor_status,
+                             const gss_OID desired_mech,
+                             const gss_OID desired_object,
+                             gss_buffer_t value)
+{
+    uint32_t retmaj = GSS_S_COMPLETE;
+    uint32_t retmin = 0;
+
+    if (minor_status == NULL) {
+        return GSS_S_CALL_INACCESSIBLE_WRITE;
+    }
+
+    if (desired_mech != GSS_C_NO_OID &&
+        !gss_oid_equal(desired_mech, &gssntlm_oid)) {
+        return GSSERRS(0, GSS_S_BAD_MECH);
+    }
+
+    if (desired_object == GSS_C_NO_OID) {
+        return GSSERRS(0, GSS_S_CALL_INACCESSIBLE_READ);
+    }
+
+    if (!gss_oid_equal(desired_object, &gssntlm_debug_oid)) {
+        return GSSERRS(EINVAL, GSS_S_UNAVAILABLE);
+    }
+
+    retmin = gssntlm_debug_invoke(value);
+    if (retmin != 0) {
+        retmaj = GSS_S_UNAVAILABLE;
+    }
+
+    return GSSERR();
+}

--- a/src/gss_ntlmssp.h
+++ b/src/gss_ntlmssp.h
@@ -176,6 +176,11 @@ uint32_t gssntlm_context_is_valid(struct gssntlm_ctx *ctx,
 
 int gssntlm_get_lm_compatibility_level(void);
 
+uint32_t gssntlm_mech_invoke(uint32_t *minor_status,
+                             const gss_OID desired_mech,
+                             const gss_OID desired_object,
+                             gss_buffer_t value);
+
 void gssntlm_int_release_name(struct gssntlm_name *name);
 void gssntlm_int_release_cred(struct gssntlm_cred *cred);
 

--- a/src/gss_spi.c
+++ b/src/gss_spi.c
@@ -443,3 +443,12 @@ OM_uint32 gss_inquire_attrs_for_mech(OM_uint32 *minor_status,
     return gssntlm_inquire_attrs_for_mech(minor_status, mech_oid, mech_attrs,
                                           known_mech_attrs);
 }
+
+OM_uint32 gssspi_mech_invoke(OM_uint32 *minor_status,
+                             const gss_OID desired_mech,
+                             const gss_OID desired_object,
+                             gss_buffer_t value)
+{
+    return gssntlm_mech_invoke(minor_status, desired_mech, desired_object,
+                               value);
+}

--- a/src/gssapi_ntlmssp.h
+++ b/src/gssapi_ntlmssp.h
@@ -53,6 +53,14 @@ extern "C" {
 #define GSS_NTLMSSP_RESET_CRYPTO_OID_STRING GSS_NTLMSSP_BASE_OID_STRING "\x03"
 #define GSS_NTLMSSP_RESET_CRYPTO_OID_LENGTH GSS_NTLMSSP_BASE_OID_LENGTH + 1
 
+/* Debug OID for mech_invoke
+ * Use this with gsspi_mech_invoke, to pass a file name and enable debugging.
+ */
+#define GSS_NTLMSSP_DEBUG_OID_STRING GSS_NTLMSSP_BASE_OID_STRING "\x04"
+#define GSS_NTLMSSP_DEBUG_OID_LENGTH GSS_NTLMSSP_BASE_OID_LENGTH + 1
+
+
+
 #define GSS_NTLMSSP_CS_DOMAIN "ntlmssp_domain"
 #define GSS_NTLMSSP_CS_NTHASH "ntlmssp_nthash"
 #define GSS_NTLMSSP_CS_PASSWORD "ntlmssp_password"

--- a/tests/env2.sh
+++ b/tests/env2.sh
@@ -2,6 +2,13 @@
 
 EXAMPLES=$(dirname "$0")/../examples
 
+export NTLMSSP_TEST_DEBUG="tests-trace-2.log"
+
 export NTLM_USER_FILE="${EXAMPLES}/test_user_file3.txt"
 export TEST_USER_NAME="TESTDOM\\testuser"
 ./ntlmssptest
+
+if [ ! -f "tests-trace-2.log" ]; then
+  echo "Debug trace file not found!"
+  exit -1
+fi

--- a/tests/ntlmssptest.c
+++ b/tests/ntlmssptest.c
@@ -2790,14 +2790,40 @@ int test_import_name(void)
     return ret;
 }
 
+int test_debug(void)
+{
+    char *test_env;
+    uint32_t maj, min;
+
+    test_env = getenv("NTLMSSP_TEST_DEBUG");
+    if (test_env) {
+        fprintf(stderr, "%s\n", test_env);
+        gss_buffer_desc val = { strlen(test_env), test_env };
+        maj = gssntlm_mech_invoke(&min, discard_const(&gssntlm_oid),
+                                  discard_const(&gssntlm_debug_oid), &val);
+        if (maj != GSS_S_COMPLETE) {
+            fprintf(stderr, "%d %d\n", maj, min);
+            return 1;
+        }
+        return 0;
+    }
+
+    /* enable trace debugging by default in tests */
+    setenv("GSSNTLMSSP_DEBUG", "tests-trace.log", 0);
+
+    return 0;
+}
+
 int main(int argc, const char *argv[])
 {
     struct ntlm_ctx *ctx;
     int gret = 0;
     int ret;
 
-    /* enable trace debugging by dfault in tests */
-    setenv("GSSNTLMSSP_DEBUG", "tests-trace.log", 0);
+    fprintf(stderr, "Test setup debug\n");
+    ret = test_debug();
+    fprintf(stderr, "Test: %s\n", (ret ? "FAIL":"SUCCESS"));
+    if (ret) gret++;
 
     fprintf(stderr, "Test errors\n");
     ret = test_Errors();


### PR DESCRIPTION
This allows to set a file of own chosing as well as turn on and off
debugging as needed.
Thread safe, and applies to all threads at once.

resolves #53 