### PR TITLE
Fix setting INTEG/CONF on ISC call.

### DIFF
--- a/src/gss_sec_ctx.c
+++ b/src/gss_sec_ctx.c
@@ -398,7 +398,7 @@ uint32_t gssntlm_init_sec_context(uint32_t *minor_status,
             ctx->gss_flags |= GSS_C_INTEG_FLAG;
         }
         if (ctx->neg_flags & NTLMSSP_NEGOTIATE_SEAL) {
-            ctx->gss_flags |= GSS_C_CONF_FLAG & GSS_C_INTEG_FLAG;
+            ctx->gss_flags |= GSS_C_CONF_FLAG | GSS_C_INTEG_FLAG;
         }
 
         ctx->stage = NTLMSSP_STAGE_DONE;


### PR DESCRIPTION
When SEAL is negotiated we are supposed to se INTEG and CONF flags, but
instead of using a | to set both a & was used ending up setting nothing.

Fixes #56