### PR TITLE
Fix offset calculation for the MIC field to match the specification

### DIFF
--- a/src/gss_ntlmssp.h
+++ b/src/gss_ntlmssp.h
@@ -18,7 +18,8 @@
                 NTLMSSP_NEGOTIATE_NTLM | \
                 NTLMSSP_REQUEST_TARGET | \
                 NTLMSSP_NEGOTIATE_OEM | \
-                NTLMSSP_NEGOTIATE_UNICODE)
+                NTLMSSP_NEGOTIATE_UNICODE | \
+                NTLMSSP_NEGOTIATE_VERSION)
 
 #define NTLMSSP_DEFAULT_SERVER_FLAGS ( \
                 NTLMSSP_NEGOTIATE_ALWAYS_SIGN | \

--- a/src/ntlm.c
+++ b/src/ntlm.c
@@ -1199,9 +1199,7 @@ int ntlm_encode_auth_msg(struct ntlm_ctx *ctx,
     if (enc_sess_key) {
         buffer.length += enc_sess_key->length;
     }
-    if ((flags & NTLMSSP_NEGOTIATE_VERSION) || mic) {
-        buffer.length += sizeof(struct wire_version);
-    }
+    buffer.length += sizeof(struct wire_version);
     if (mic) {
         buffer.length += 16;
     }
@@ -1219,9 +1217,7 @@ int ntlm_encode_auth_msg(struct ntlm_ctx *ctx,
         ret = ntlm_encode_version(ctx, &buffer, &data_offs);
         if (ret) goto done;
     }
-    else if (mic) {
-        /* the space for version is always present in the layout
-         * if MIC is present */
+    else {
         memset(&buffer.data[data_offs], 0, sizeof(struct wire_version));
         data_offs += sizeof(struct wire_version);
     }

--- a/src/ntlm_crypto.c
+++ b/src/ntlm_crypto.c
@@ -962,20 +962,12 @@ int ntlm_verify_mic(struct ntlm_key *key,
 {
     uint8_t micbuf[NTLM_SIGNATURE_SIZE];
     struct ntlm_buffer check_mic = { micbuf, NTLM_SIGNATURE_SIZE };
-    struct wire_auth_msg *msg;
     size_t payload_offs;
-    uint32_t flags;
     int ret;
 
-    msg = (struct wire_auth_msg *)authenticate_message->data;
     payload_offs = offsetof(struct wire_auth_msg, payload);
-
-    /* flags must be checked as they may push the payload further down */
-    flags = le32toh(msg->neg_flags);
-    if (flags & NTLMSSP_NEGOTIATE_VERSION) {
-        /* skip version for now */
-        payload_offs += sizeof(struct wire_version);
-    }
+    /* if MIC is present then there's always a reserved space for version */
+    payload_offs += sizeof(struct wire_version);
 
     if (payload_offs + NTLM_SIGNATURE_SIZE > authenticate_message->length) {
         return EINVAL;


### PR DESCRIPTION
In most cases the change is bening because NTLMSSP_NEGOTIATE_VERSION
is sent by the server in CHALLENGE_MESSAGE and then repeated in
AUTHENTICATION_MESSAGE which results in the correct offset being used.

To reduce the chance of breaking implementations that don't send the
NTLMSSP_NEGOTIATE_VERSION flag in CHALLENGE_MESSAGE it is also added
to NEGOTIATE_MESSAGE in the initial exchange.

Fixes #62 