### PR TITLE
Always include a version field in NTLMSSP packets

### DIFF
--- a/src/gss_ntlmssp.h
+++ b/src/gss_ntlmssp.h
@@ -18,7 +18,8 @@
                 NTLMSSP_NEGOTIATE_NTLM | \
                 NTLMSSP_REQUEST_TARGET | \
                 NTLMSSP_NEGOTIATE_OEM | \
-                NTLMSSP_NEGOTIATE_UNICODE)
+                NTLMSSP_NEGOTIATE_UNICODE | \
+                NTLMSSP_NEGOTIATE_VERSION)
 
 #define NTLMSSP_DEFAULT_SERVER_FLAGS ( \
                 NTLMSSP_NEGOTIATE_ALWAYS_SIGN | \

--- a/src/gss_sec_ctx.c
+++ b/src/gss_sec_ctx.c
@@ -673,6 +673,18 @@ uint32_t gssntlm_accept_sec_context(uint32_t *minor_status,
 
             /* leave only the crossing between requested and allowed flags */
             ctx->neg_flags &= in_flags;
+
+            /* Try to force the use of NTLMSSP_NEGOTIATE_VERSION even if the
+             * client did not advertize it in their negotiate message, but
+             * should be capable of providing it.
+             * This is what Windows Server 2022 also does, and addresses
+             * issues with older clients that incorrectly deal with MIC
+             * calculations in absence of this flag. */
+            if ((ctx->neg_flags & (NTLMSSP_NEGOTIATE_ALWAYS_SIGN |
+                                    NTLMSSP_NEGOTIATE_SEAL |
+                                    NTLMSSP_NEGOTIATE_SIGN))) {
+                ctx->neg_flags |= NTLMSSP_NEGOTIATE_VERSION;
+            }
         } else {
             /* If there is no negotiate message set datagram mode */
             ctx->neg_flags |= NTLMSSP_NEGOTIATE_DATAGRAM | \

--- a/src/ntlm_common.h
+++ b/src/ntlm_common.h
@@ -88,12 +88,26 @@ struct wire_field_hdr {
 };
 #pragma pack(pop)
 
+/* Version information.
+ * Used only for debugging and usually placed as the head of the payload when
+ * used */
+#pragma pack(push, 1)
+struct wire_version {
+    uint8_t major;
+    uint8_t minor;
+    uint16_t build;
+    uint8_t reserved[3];
+    uint8_t revision;
+};
+#pragma pack(pop)
+
 #pragma pack(push, 1)
 struct wire_neg_msg {
     struct wire_msg_hdr header;
     uint32_t neg_flags;
     struct wire_field_hdr domain_name;
     struct wire_field_hdr workstation_name;
+    struct wire_version version;
     uint8_t payload[]; /* variable */
 };
 #pragma pack(pop)
@@ -106,6 +120,7 @@ struct wire_chal_msg {
     uint8_t server_challenge[8];
     uint8_t reserved[8];
     struct wire_field_hdr target_info;
+    struct wire_version version;
     uint8_t payload[]; /* variable */
 };
 #pragma pack(pop)
@@ -131,20 +146,8 @@ struct wire_auth_msg {
     struct wire_field_hdr workstation;
     struct wire_field_hdr enc_sess_key;
     uint32_t neg_flags;
+    struct wire_version version;
     uint8_t payload[]; /* variable */
-};
-#pragma pack(pop)
-
-/* Version information.
- * Used only for debugging and usually placed as the head of the payload when
- * used */
-#pragma pack(push, 1)
-struct wire_version {
-    uint8_t major;
-    uint8_t minor;
-    uint16_t build;
-    uint8_t reserved[3];
-    uint8_t revision;
 };
 #pragma pack(pop)
 


### PR DESCRIPTION
It turns out that the version field structure must always be included
in packets, the flag only controls whether the structure is filled or
all zeros.
Add it directly to the wire structures, and change the encoding
functions accordingly.

Fixes #62 