### PR TITLE
Revert the MSVAVFLAGS_UNVERIFIED_SPN flag default

### DIFF
--- a/src/gss_sec_ctx.c
+++ b/src/gss_sec_ctx.c
@@ -730,7 +730,15 @@ uint32_t gssntlm_accept_sec_context(uint32_t *minor_status,
             goto done;
         }
 
-        av_flags = MSVAVFLAGS_UNVERIFIED_SPN;
+        /* TODO: allow client applications to set a context option to
+         * provide an av_flags default value so that flags like
+         * MSVAVFLAGS_UNVERIFIED_SPN can be set. By default SSPI does
+         * not set this flag, and setting it causes servers with restrictive
+         * policy to fail authentication. Given no MS client set this flag
+         * by default, neither should we until there is a clear need. We
+         * trust our calling applications to do the right thing here.
+         * av_flags = MSVAVFLAGS_UNVERIFIED_SPN;
+         */
 
         timestamp = ntlm_timestamp_now();
 

--- a/src/ntlm.c
+++ b/src/ntlm.c
@@ -814,7 +814,6 @@ int ntlm_process_target_info(struct ntlm_ctx *ctx, bool protect,
             ret = ENOMEM;
             goto done;
         }
-        av_flags |= MSVAVFLAGS_UNVERIFIED_SPN;
     }
 
     ret = ntlm_encode_target_info(ctx,


### PR DESCRIPTION
By default SSPI does not set this flag, and setting it causes servers
with restrictive policy to fail authentication. Given no MS client sets
this flag by default, neither should we until there is a clear need.
We trust our calling applications to do the right thing here in any
case just like SSPI trusts their own calling applications.

Fixes #67 