### PR TITLE
Fix typo in header guard for src/ntlm.h

### DIFF
--- a/src/ntlm.h
+++ b/src/ntlm.h
@@ -1,7 +1,7 @@
 /* Copyright 2013 Simo Sorce <simo@samba.org>, see COPYING for license */
 
 #ifndef _NTLM_H_
-#define _NTLM_H
+#define _NTLM_H_
 
 #include <stdbool.h>
 


### PR DESCRIPTION
Header guard fails due to typo as the header guard is checking for a different macro identifier than it defines