### PR TITLE
BF: libiconv does not support undashed unicode encoding aliases

### DIFF
--- a/src/ntlm.c
+++ b/src/ntlm.c
@@ -78,12 +78,12 @@ int ntlm_init_ctx(struct ntlm_ctx **ctx)
     _ctx = calloc(1, sizeof(struct ntlm_ctx));
     if (!_ctx) return ENOMEM;
 
-    _ctx->from_oem = iconv_open("UTF16LE", "UTF-8");
+    _ctx->from_oem = iconv_open("UTF-16LE", "UTF-8");
     if (_ctx->from_oem == (iconv_t) -1) {
         ret = errno;
     }
 
-    _ctx->to_oem = iconv_open("UTF-8", "UTF16LE");
+    _ctx->to_oem = iconv_open("UTF-8", "UTF-16LE");
     if (_ctx->to_oem == (iconv_t) -1) {
         iconv_close(_ctx->from_oem);
         ret = errno;

--- a/src/ntlm_crypto.c
+++ b/src/ntlm_crypto.c
@@ -50,7 +50,7 @@ int NTOWFv1(const char *password, struct ntlm_key *result)
     int ret;
 
     len = strlen(password);
-    retstr = u8_conv_to_encoding("UTF16LE", iconveh_error,
+    retstr = u8_conv_to_encoding("UTF-16LE", iconveh_error,
                                  (const uint8_t *)password, len,
                                  NULL, NULL, &out);
     if (!retstr) return ERR_CRYPTO;
@@ -254,7 +254,7 @@ int NTOWFv2(struct ntlm_ctx *ctx, struct ntlm_key *nt_hash,
         offs += len;
     }
 
-    retstr = (uint8_t *)u8_conv_to_encoding("UTF16LE", iconveh_error,
+    retstr = (uint8_t *)u8_conv_to_encoding("UTF-16LE", iconveh_error,
                                             upcased, offs, NULL, NULL, &out);
     if (!retstr) return ERR_CRYPTO;
 


### PR DESCRIPTION
# Problem description
In commit [Use UCS16LE instead of UCS-2LE](https://github.com/gssapi/gss-ntlmssp/commit/36b3a2685f235a24e5a0a7fb84ca055aab57acac ) UCS2LE was swapped for UTF16LE. This change works fine if libunistring is using the GLIBC iconv_* symbols. However, if libunistring is linked to libiconv instead, the change breaks this library.

In the libiconv manual there is no explicit mention to aliases without dashes being supported, and testing revealed that it in fact does not. https://www.gnu.org/software/libiconv/

# Solution
Replace "UTF16LE" with "UTF-16LE" in libunistring calls

# Test
 1. build libunistring while linking to libiconv
 2. build gssntlmssp linking to the built libunistring
 3. Test usage of NTOWFv1. Function produced the correct value; returned 0.


